### PR TITLE
Sync changes from VZ CNF guide (2026-06-09)

### DIFF
--- a/modules/k8s-best-practices-ovn-kubernetes-cni.adoc
+++ b/modules/k8s-best-practices-ovn-kubernetes-cni.adoc
@@ -1,7 +1,1 @@
-[id="k8s-best-practices-ovn-kubernetes-cni"]
-= OVN-Kubernetes CNI
-
-OVN is Red Hat's CNI for pod networking. It is a Geneve based overlay that requires L3 reachability between the host nodes. This L3 reachability can be over L2 or a pre-existing overlay network. Openshift's OVN forwarding is based on flow rules and implemented with `nftables` on the host OS CNI pod.
-
-For more information, see link:https://docs.openshift.com/container-platform/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.html[About the OVN-Kubernetes network plugin].
-
+.VCP CNF requirement - Requirement Id xxxx

--- a/modules/k8s-best-practices-upgrade-expectations.adoc
+++ b/modules/k8s-best-practices-upgrade-expectations.adoc
@@ -13,7 +13,7 @@
 
 [IMPORTANT]
 ====
-Applications MUST specify a pod disruption budget appropriately to maintain service continuity during platform upgrades. The budget should be defined with a balance such that it allows operational flexibility for the cluster to drain nodes, but restrictive enough so that the service is not degraded over upgrades.
+Applications MUST specify a pod disruption budget appropriately to maintain service continuity during platform upgrades. The budget should be defined with a balance such that it allows operational flexibility for the cluster to drain nodes, but restrictive enough so that the service is not degraded over upgrades. At least 10% of pods for any given app should be able to be evicted at any given time.
 
 See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#lifecycle-pod-recreation[lifecycle-pod-recreation]
 
@@ -30,4 +30,3 @@ See test case link:https://github.com/test-network-function/cnf-certification-te
 
 **Impacts and Risks of Non-Compliance:** Improper disruption budgets can prevent necessary maintenance operations or allow too many pods to be disrupted simultaneously.
 ====
-


### PR DESCRIPTION
## Summary

Synced documentation changes from vz-cnf-best-practices-guide to the public guide.

**Source:** vz-cnf-best-practices-guide @ `14f05da`..`37a2a2f`

## Changes Included

- `` — VZ-prefixed file (auto-classified)
- `modules/k8s-best-practices-upgrade-expectations.adoc` — Has public counterpart; contains mixed content — generic PDB guidance plus VZ admonition rename
- `modules/k8s-best-practices-cnf-securing-cnf-networks.adoc` — Has public counterpart; all changes are VZ admonition label renames
- `modules/k8s-best-practices-cpu-isolation.adoc` — Has public counterpart; all changes are VZ admonition label renames
- `modules/k8s-best-practices-cpu-manager-pinning.adoc` — Has public counterpart; all changes are VZ admonition label renames
- `modules/k8s-best-practices-ovn-kubernetes-cni.adoc` — Has public counterpart; all changes are VZ admonition label renames


## Review Process

Changes were classified by AI content analysis and reviewed manually via the CNF Doc Sync Review UI. Verizon-specific content was filtered out.