### PR TITLE
Sync changes from VZ CNF guide (2026-06-10)

### DIFF
--- a/modules/k8s-best-practices-upgrade-expectations.adoc
+++ b/modules/k8s-best-practices-upgrade-expectations.adoc
@@ -1,6 +1,8 @@
 [id="k8s-best-practices-upgrade-expectations"]
 = Upgrade expectations
 
+Modified by Banashri
+
 * The Kubernetes API deprecation policy defined in link:https://kubernetes.io/docs/reference/using-api/deprecation-policy/[Kubernetes Deprecation Policy] shall be followed.
 
 * Workloads are expected to maintain service continuity during platform upgrades, and during workload version upgrades
@@ -13,7 +15,7 @@
 
 [IMPORTANT]
 ====
-Applications MUST specify a pod disruption budget appropriately to maintain service continuity during platform upgrades. The budget should be defined with a balance such that it allows operational flexibility for the cluster to drain nodes, but restrictive enough so that the service is not degraded over upgrades.
+Applications MUST specify a pod disruption budget appropriately to maintain service continuity during platform upgrades. The budget should be defined with a balance such that it allows operational flexibility for the cluster to drain nodes, but restrictive enough so that the service is not degraded over upgrades. At least 10% of pods for any given app should be able to be evicted at any given time.
 
 See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#lifecycle-pod-recreation[lifecycle-pod-recreation]
 
@@ -30,4 +32,3 @@ See test case link:https://github.com/test-network-function/cnf-certification-te
 
 **Impacts and Risks of Non-Compliance:** Improper disruption budgets can prevent necessary maintenance operations or allow too many pods to be disrupted simultaneously.
 ====
-


### PR DESCRIPTION
## Summary

Synced documentation changes from vz-cnf-best-practices-guide to the public guide.

**Source:** vz-cnf-best-practices-guide @ `14f05da`..`37a2a2f`

## Changes Included

- `modules/k8s-best-practices-upgrade-expectations.adoc` — Has public counterpart; contains mixed content — generic PDB guidance plus VZ admonition rename


## Review Process

Changes were classified by AI content analysis and reviewed manually via the CNF Doc Sync Review UI. Verizon-specific content was filtered out.