### PR TITLE
Sync changes from VZ CNF guide (2026-06-11)

### DIFF
--- a/modules/k8s-best-practices-cpu-isolation.adoc
+++ b/modules/k8s-best-practices-cpu-isolation.adoc
@@ -1,17 +1,70 @@
 [id="k8s-best-practices-cpu-isolation"]
+[id="cpu-isolation"]
 = CPU isolation
 
-The Node Tuning Operator manages host CPUs by dividing them into reserved CPUs for cluster and operating system housekeeping duties, and isolated CPUs for workloads. CPUs that are used for low latency workloads are set as isolated.
+All the worker nodes in Webscale clusters have following performance profile applied to support Isolated CPUs with variations on the specific CPUs reserved or isolated based on the hardware.
 
-Device interrupts are load balanced between all isolated and reserved CPUs to avoid CPUs being overloaded, with the exception of CPUs where there is a guaranteed pod running. Guaranteed pod CPUs are prevented from processing device interrupts when the relevant annotations are set for the pod.
+[source,yaml]
+----
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  annotations:
+    kubeletconfig.experimental: |
+      {"allowedUnsafeSysctls": ["net.*"], "systemReserved": {"memory": "16Gi", "cpu": "4", "ephemeral-storage": "1Gi"}}
+  name: perf-profile-2m-worker
+spec:
+  cpu:
+    isolated: 2-39,42-79
+    reserved: 0-1,40-41
+  hugepages:
+    defaultHugepagesSize: 2M
+    pages:
+    - count: 24000
+      node: 0
+      size: 2M
+    - count: 24000
+      node: 1
+      size: 2M
+  nodeSelector:
+    node-role.kubernetes.io/workerperf: ""
+  numa:
+    topologyPolicy: single-numa-node
+  realTimeKernel:
+    enabled: false
+  workloadHints:
+    realTime: false
+----
 
-.Workload requirement
-[IMPORTANT]
-====
-To use isolated CPUs, specific annotations must be defined in the pod specification.
+* `isolated` - Has the lowest latency. Processes in this group have no interruptions and so can, for example, reach much higher DPDK zero packet loss bandwidth.
+* `reserved` - The housekeeping CPUs. Threads in the reserved group tend to be very busy, so latency-sensitive applications should be run in the isolated group
 
-See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#lifecycle-cpu-isolation[lifecycle-cpu-isolation]
 
-**Impacts and Risks of Non-Compliance:** Improper CPU isolation can cause performance interference between workloads and fail to provide guaranteed compute resources.
-====
+DPDK based application must use following annotations:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dpdk-pod
+  annotations:
+    cpu-quota.crio.io: "disable" # Mandatory for DPDK zero packet loss. Disables CPU CFS quota at pod run time
+    irq-load-balancing.crio.io: "disable" # Mandatory for DPDK zero packet loss. Disables device interrupts on guaranteed CPUs
+    cpu-load-balancing.crio.io: "disable" # Optional, depends on the CNF implementation
+    cpu-c-states.crio.io: "disable" # Optional, depends on the CNF implementation
+    cpu-freq-governor.crio.io: "performance" # Optional, depends on the CNF implementation
+spec:
+  runtimeClassName: performance-perf-profile-2m-worker #  If not provided, above annotations will be silently ignored, MUST match the name of the performance profile
+----
+
+Additionally, pods which require guaranteed resources must use CPU settings for Requests and Limits to an equal value which is an even number. This allows the pod to be scheduled on a full core within a hyperthreaded environment. Attempting to set an odd number of guaranteed cores (where requests are equal to limits) will result in the pod failing to start.
+
+For a pod to be classified as Guaranteed the following conditions must exist:
+
+* Every container in the Pod must have a memory limit and a memory request
+* For every container in the Pod, the memory limit must equal the memory request
+* Every container in the Pod must have a CPU limit and a CPU request
+* For every container in the Pod, the CPU limit must equal the CPU request
+
 

--- a/modules/k8s-best-practices-ovn-kubernetes-cni.adoc
+++ b/modules/k8s-best-practices-ovn-kubernetes-cni.adoc
@@ -1,7 +1,8 @@
 [id="k8s-best-practices-ovn-kubernetes-cni"]
 = OVN-Kubernetes CNI
 
-OVN is Red Hat's CNI for pod networking. It is a Geneve based overlay that requires L3 reachability between the host nodes. This L3 reachability can be over L2 or a pre-existing overlay network. Openshift's OVN forwarding is based on flow rules and implemented with `nftables` on the host OS CNI pod.
+OVN is Red Hat's CNI for pod networking. It is a Geneve based overlay that requires L3 reachability between the host nodes. This L3 reachability can be over L2 or a pre-existing overlay network. Openshift's OVN forwarding is based on flow rules and implemented with nftables on the host OS CNI pod.
+
+Because some CNFs have expressed the need for additional features that the kernel SCTP module does not support, the SCTP module is disabled in the kernel on all the hosts in VCP Webscale. However, SCTP is enabled on the CNI realized via OVN rules with k8s feature gate. CNFs must bring their own SCTP user space module if they would like to use SCTP on the pod or a Multus network. Additionally the SPK load balancer can support conversion of SCTP to TCP for some protocols. 
 
 For more information, see link:https://docs.openshift.com/container-platform/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.html[About the OVN-Kubernetes network plugin].
-

--- a/modules/k8s-best-practices-upgrade-expectations.adoc
+++ b/modules/k8s-best-practices-upgrade-expectations.adoc
@@ -1,33 +1,20 @@
 [id="k8s-best-practices-upgrade-expectations"]
 = Upgrade expectations
 
-* The Kubernetes API deprecation policy defined in link:https://kubernetes.io/docs/reference/using-api/deprecation-policy/[Kubernetes Deprecation Policy] shall be followed.
+* CNF vendors should expect that VCP Webscale Platform shall be upgraded to new versions on an ongoing basis employing CI/CD runtime deployment without any advance notice to CNF vendors.
 
-* Workloads are expected to maintain service continuity during platform upgrades, and during workload version upgrades
+* During VCP WebScale platform upgrades, the Kubernetes API deprecation policy defined in link:https://kubernetes.io/docs/reference/using-api/deprecation-policy/[Kubernetes Deprecation Policy] shall be followed
 
-* Workloads need to be prepared for nodes to reboot or shut down without notice
+* CNFs are expected to maintain service continuity during Platform Upgrades, and during CNF version upgrades
 
-* Workloads shall configure pod disruption budget appropriately to maintain service continuity during platform upgrades
+* CNFs need to be prepared for nodes to reboot or shut down without notice.
 
-* Applications should not be tied to a specific version of Kubernetes or any of its components
+* CNFs shall configure pod disruption budget appropriately to maintain service continuity during platform upgrades Applications should not be tied to a specific version of Kubernetes or any of its components
 
 [IMPORTANT]
 ====
-Applications MUST specify a pod disruption budget appropriately to maintain service continuity during platform upgrades. The budget should be defined with a balance such that it allows operational flexibility for the cluster to drain nodes, but restrictive enough so that the service is not degraded over upgrades.
+Applications MUST specify a pod disruption budget appropriately to maintain service continuity during platform upgrades. The budget should be defined with a balance such that it allows operational flexibility for the cluster to drain nodes, but restrictive enough so that the service is not degraded over upgrades. At least 10% of pods for any given app should be able to be evicted at any given time.
 
 See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#lifecycle-pod-recreation[lifecycle-pod-recreation]
-
-**Impacts and Risks of Non-Compliance:** Failed pod recreation indicates poor high availability configuration, leading to potential service outages during node failures.
-====
-
-.Workload requirement
-[IMPORTANT]
-====
-Pods that perform the same microservice and that could be disrupted if multiple members of the service are
-unavailable must implement pod disruption budgets to prevent disruption in the event of patches/upgrades.
-
-See test case link:https://github.com/test-network-function/cnf-certification-test/blob/main/CATALOG.md#observability-pod-disruption-budget[observability-pod-disruption-budget]
-
-**Impacts and Risks of Non-Compliance:** Improper disruption budgets can prevent necessary maintenance operations or allow too many pods to be disrupted simultaneously.
 ====
 


### PR DESCRIPTION
## Summary

Synced documentation changes from vz-cnf-best-practices-guide to the public guide.

**Source:** vz-cnf-best-practices-guide @ `e9a66a20`..`37a2a2f`

## Changes Included

- `main.adoc` — Structural change removing deprecated cni-ovn module include
- `modules/k8s-best-practices-cpu-isolation.adoc` — Has public counterpart, contains mixed generic/VZ content
- `modules/k8s-best-practices-ovn-kubernetes-cni.adoc` — Has public counterpart, contains mixed generic/VZ content
- `modules/k8s-best-practices-upgrade-expectations.adoc` — Has public counterpart, contains mixed generic/VZ content


## Review Process

Changes were classified by AI content analysis and reviewed manually via the CNF Doc Sync Review UI. Verizon-specific content was filtered out.